### PR TITLE
Restrict token database to owner-only permissions

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -1,4 +1,5 @@
 import { DatabaseSync } from 'node:sqlite';
+import { chmodSync } from 'fs';
 import { homedir } from 'os';
 import { join } from 'path';
 
@@ -9,6 +10,13 @@ let db;
 function getDb() {
   if (!db) {
     db = new DatabaseSync(DB_PATH);
+    // The DB holds plaintext refresh tokens — keep it owner-only. SQLite creates
+    // the file with the process umask (typically 0644), so narrow it explicitly.
+    try {
+      chmodSync(DB_PATH, 0o600);
+    } catch {
+      // Non-fatal: a read-only or exotic filesystem shouldn't block startup
+    }
     db.exec(`
       CREATE TABLE IF NOT EXISTS accounts (
         email         TEXT PRIMARY KEY,

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -2,6 +2,7 @@ import { randomBytes } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { rm } from 'node:fs/promises';
+import { statSync } from 'node:fs';
 import { describe, it, after } from 'node:test';
 import assert from 'node:assert/strict';
 
@@ -159,5 +160,20 @@ describe('removeAccount', () => {
 
   it('is a no-op for unknown email', () => {
     assert.doesNotThrow(() => removeAccount('nobody@example.com'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// file permissions
+// ---------------------------------------------------------------------------
+
+describe('database file permissions', () => {
+  it('is not readable or writable by group or other', () => {
+    // The DB stores refresh tokens in plaintext, so it must stay owner-only.
+    // SQLite creates the file using the process umask (commonly 0644), which
+    // would otherwise leave tokens world-readable.
+    storeTokens('perms@example.com', BASE_TOKENS);
+    const mode = statSync(DB_PATH).mode & 0o777;
+    assert.equal(mode & 0o077, 0, `expected no group/other bits, got ${mode.toString(8)}`);
   });
 });


### PR DESCRIPTION
### Problem

`~/.gmail-mcp-tokens.db` stores OAuth access and refresh tokens in plaintext. SQLite creates the file using the process umask, which on a default macOS/Linux setup yields mode `0644`:

```
$ stat -f '%Sp' ~/.gmail-mcp-tokens.db
-rw-r--r--
```

That leaves refresh tokens readable by any other local user or process. Under the scopes this server requests (`gmail.readonly`, `gmail.send`, `gmail.modify`, `gmail.labels`), a refresh token grants durable read/send/modify access to the mailbox until it is manually revoked — and refresh tokens do not expire once the OAuth app is published to production.

`~/.gmail-mcp-oauth.json` is typically `0600` because it comes straight from a browser download, so the token DB is the weaker of the two files despite holding the more powerful credential.

### Fix

`chmod 0600` on the database when it is opened.

Applied on every open rather than only at creation, so existing installations are corrected on next start rather than staying `0644` indefinitely. The call is wrapped in a `try/catch` so a read-only or otherwise unusual filesystem cannot block startup.

### Test

Adds a regression test asserting no group/other bits are set. Verified it fails without the fix:

```
AssertionError [ERR_ASSERTION]: expected no group/other bits, got 644
```

Full suite passes with the fix: 48/48.

### Notes

This narrows filesystem exposure only — tokens remain plaintext at rest. Encrypting them or moving them to the platform keychain would be a larger change; happy to look at that separately if you're interested.
