### PR TITLE
fix: encode non-ASCII Subject headers per RFC 2047

### DIFF
--- a/src/gmail-client.js
+++ b/src/gmail-client.js
@@ -46,13 +46,21 @@ export function extractBody(payload) {
   return '';
 }
 
+// Encodes a header value as an RFC 2047 encoded-word when it contains
+// non-ASCII characters (raw UTF-8 is not valid in message headers and
+// renders as mojibake in receiving clients).
+function encodeHeader(value) {
+  if (!value || /^[\x00-\x7F]*$/.test(value)) return value;
+  return `=?UTF-8?B?${Buffer.from(value, 'utf8').toString('base64')}?=`;
+}
+
 export function buildRaw({ from, to, cc, bcc, subject, body, inReplyTo, references }) {
   const lines = [
     `From: ${from}`,
     `To: ${to}`,
     cc ? `Cc: ${cc}` : null,
     bcc ? `Bcc: ${bcc}` : null,
-    `Subject: ${subject}`,
+    `Subject: ${encodeHeader(subject)}`,
     'Content-Type: text/plain; charset=UTF-8',
     inReplyTo ? `In-Reply-To: ${inReplyTo}` : null,
     references ? `References: ${references}` : null,

--- a/test/gmail-client.test.js
+++ b/test/gmail-client.test.js
@@ -111,6 +111,23 @@ describe('buildRaw', () => {
     assert.ok(decoded.includes('Content-Type: text/plain; charset=UTF-8'), 'missing Content-Type');
   });
 
+  it('encodes non-ASCII subjects as RFC 2047 encoded-words', () => {
+    const subject = 'Test \u2014 la bo\u00eete est op\u00e9rationnelle';
+    const decoded = decodeRaw(
+      buildRaw({ from: 'a@x.com', to: 'b@y.com', subject, body: '' })
+    );
+    const match = decoded.match(/Subject: =\?UTF-8\?B\?(.+)\?=/);
+    assert.ok(match, 'subject is not an RFC 2047 encoded-word');
+    assert.equal(Buffer.from(match[1], 'base64').toString('utf8'), subject);
+  });
+
+  it('leaves ASCII-only subjects unencoded', () => {
+    const decoded = decodeRaw(
+      buildRaw({ from: 'a@x.com', to: 'b@y.com', subject: 'Plain subject', body: '' })
+    );
+    assert.ok(decoded.includes('Subject: Plain subject'));
+  });
+
   it('separates headers from body with \\r\\n\\r\\n', () => {
     const decoded = decodeRaw(
       buildRaw({ from: 'a@x.com', to: 'b@y.com', subject: 'Hi', body: 'Body text' })


### PR DESCRIPTION
## Problem

`buildRaw` writes the subject into the `Subject:` header as raw UTF-8. RFC 5322 headers only allow ASCII, so any accented or non-Latin subject arrives as mojibake in receiving clients.

**Repro:** `send_email` with subject `Test — la boîte est opérationnelle` → Gmail/Apple Mail display `Test Ã¢Â€Â" la boÃƒÂ®te est opÃƒÂ©rationnelle`. The body is unaffected because it has an explicit `charset=UTF-8` content type — only headers are broken.

## Fix

Encode the subject as an RFC 2047 encoded-word (`=?UTF-8?B?...?=`) when it contains non-ASCII characters; ASCII-only subjects are passed through unchanged. Since send, reply and draft all go through `buildRaw`, one change covers the three paths (including `Re: <accented subject>` on replies).

## Tests

Two cases added to the existing `buildRaw` suite: a non-ASCII subject round-trips through the encoded-word back to the original string, and an ASCII subject stays unencoded. Full suite: 50 pass / 0 fail.

Found while using the server on a French-language mailbox — happy to adjust anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)